### PR TITLE
Add Bun serve-based health check

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,13 @@
-console.log("Hello via Bun!");
+const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+
+Bun.serve({
+  port,
+  routes: {
+    "/health": Response.json({ status: "ok" }),
+  },
+  fetch() {
+    return new Response("Not Found", { status: 404 });
+  },
+});
+
+console.log(`HTTP server running on http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- rewrite server to use `Bun.serve`
- implement `/health` as a static route

## Testing
- `bun run index.ts & SERVER_PID=$!; sleep 0.5; curl -s http://localhost:3000/health; kill $SERVER_PID`

------
https://chatgpt.com/codex/tasks/task_e_6841479762048327aaf13513969bccd1