### PR TITLE
Add Railway deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy to Railway
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Railway CLI
+        run: curl -sL https://railway.app/install.sh | sh
+      - name: Deploy
+        run: railway up
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy to Railway on PR events and pushes to `main`
- streamline install step using Railway install script

## Testing
- `bun test` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68414a962d8c8327b6d0440ff386bea8